### PR TITLE
docs: Add MCP debugging setup with mcp-debug integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ make test
 make help
 ```
 
+### Debugging
+
+To debug the MCP server with [mcp-debug](https://github.com/giantswarm/mcp-debug):
+
+```bash
+# Start the server
+./scripts/start-mcp-server.sh
+
+# In another terminal, use mcp-debug
+mcp-debug --repl --endpoint http://localhost:8080/mcp
+```
+
+For development workflow (rebuild and restart):
+```bash
+./scripts/start-mcp-server.sh --restart
+```
+
+See [docs/debugging.md](docs/debugging.md) for details.
+
 ### Makefile Targets
 
 The project includes a comprehensive Makefile with the following targets:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,61 @@
+# Debugging the MCP Server
+
+## Quick Start
+
+1. **Start the inboxfewer MCP server:**
+   ```bash
+   ./scripts/start-mcp-server.sh
+   ```
+   This runs on `http://localhost:8080/mcp`
+
+2. **Use mcp-debug to connect:**
+   ```bash
+   # Interactive REPL
+   mcp-debug --repl --endpoint http://localhost:8080/mcp
+   
+   # Or via Cursor - add to .cursor/mcp.json:
+   # {
+   #   "mcpServers": {
+   #     "mcp-debug": {
+   #       "command": "mcp-debug",
+   #       "args": ["--mcp-server", "--endpoint", "http://localhost:8080/mcp"]
+   #     }
+   #   }
+   # }
+   ```
+
+## Development Workflow
+
+When making changes to inboxfewer:
+
+```bash
+# 1. Make your code changes
+# 2. Rebuild and restart
+./scripts/start-mcp-server.sh --restart
+```
+
+This will:
+- Build the binary with `go build`
+- Kill any running inboxfewer server
+- Start the new server
+
+## Available Tools
+
+- `gmail_list_threads` - List Gmail threads
+- `gmail_archive_thread` - Archive a thread
+- `gmail_classify_thread` - Classify if GitHub-related
+- `gmail_check_stale` - Check if stale (closed issue/PR)
+- `gmail_archive_stale_threads` - Archive all stale threads
+
+## REPL Examples
+
+```javascript
+// List tools
+tools
+
+// Get tool details
+tool gmail_list_threads
+
+// Execute tool
+exec gmail_list_threads '{"query": "in:inbox", "maxResults": 5}'
+```

--- a/scripts/start-mcp-server.sh
+++ b/scripts/start-mcp-server.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Start the inboxfewer MCP server for debugging
+# Usage: ./scripts/start-mcp-server.sh [--restart]
+
+set -e
+
+HTTP_PORT="8080"
+BINARY="./inboxfewer"
+
+# Check for restart flag
+RESTART=false
+if [ "$1" = "--restart" ]; then
+    RESTART=true
+fi
+
+# Build the binary
+echo "Building inboxfewer..."
+go build -o "$BINARY" .
+
+# Kill existing server if restart requested or port is in use
+if [ "$RESTART" = true ] || lsof -Pi :${HTTP_PORT} -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "Stopping existing server on port ${HTTP_PORT}..."
+    lsof -ti :${HTTP_PORT} | xargs kill 2>/dev/null || true
+    sleep 1
+fi
+
+# Start the server
+echo "Starting inboxfewer MCP server on http://localhost:${HTTP_PORT}/mcp"
+echo "Press Ctrl+C to stop"
+echo ""
+exec "$BINARY" serve --transport streamable-http --http-addr ":${HTTP_PORT}" --debug


### PR DESCRIPTION
## Summary

- Add `scripts/start-mcp-server.sh` to build and start the MCP server for debugging
- Add `docs/debugging.md` with concise debugging instructions  
- Update `README.md` with debugging section

## Overview

This PR adds infrastructure for debugging the inboxfewer MCP server during development using the [mcp-debug](https://github.com/giantswarm/mcp-debug) tool.

## Changes

### Script: `scripts/start-mcp-server.sh`
- Automatically builds the binary with `go build`
- Kills any existing server on port 8080
- Starts the server on `http://localhost:8080/mcp` with debug logging
- Supports `--restart` flag for quick rebuild during development

### Documentation: `docs/debugging.md`
- Quick start guide for using mcp-debug with inboxfewer
- Development workflow instructions
- List of available MCP tools
- REPL command examples
- Cursor integration instructions

### README Update
- Added debugging section with quick examples
- Links to detailed documentation

## Usage

```bash
# Start the MCP server
./scripts/start-mcp-server.sh

# In another terminal, connect with mcp-debug
mcp-debug --repl --endpoint http://localhost:8080/mcp

# After making code changes, rebuild and restart
./scripts/start-mcp-server.sh --restart
```

## Test Plan

- [x] Script builds and starts the server successfully
- [x] mcp-debug can connect to the running server
- [x] `--restart` flag rebuilds and restarts correctly
- [x] Documentation is clear and concise