### PR TITLE
feat(multi-account): Add multi-account support for Google services

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -32,7 +32,9 @@ func readGithubConfig() error {
 }
 
 func newCleanupCmd() *cobra.Command {
-	return &cobra.Command{
+	var account string
+
+	cmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "Clean up Gmail inbox by archiving closed GitHub issue threads",
 		Long: `Scan your Gmail inbox for threads related to GitHub issues and pull requests.
@@ -43,9 +45,9 @@ If the corresponding GitHub issue or PR is closed, the thread will be archived.`
 			}
 
 			ctx := context.Background()
-			client, err := gmail.NewClient(ctx)
+			client, err := gmail.NewClientForAccount(ctx, account)
 			if err != nil {
-				return fmt.Errorf("failed to create Gmail client: %w", err)
+				return fmt.Errorf("failed to create Gmail client for account %s: %w", account, err)
 			}
 
 			n := 0
@@ -74,6 +76,9 @@ If the corresponding GitHub issue or PR is closed, the thread will be archived.`
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&account, "account", "default", "Google account name to use (default: 'default')")
+	return cmd
 }
 
 func homeDir() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/teemow/inboxfewer/internal/google"
 )
 
 // rootCmd represents the base command for the inboxfewer application
@@ -30,6 +33,11 @@ func SetVersion(v string) {
 
 // Execute is the main entry point for the CLI application
 func Execute() {
+	// Migrate old token format to new multi-account format
+	if err := google.MigrateDefaultToken(); err != nil {
+		log.Printf("Warning: failed to migrate token: %v", err)
+	}
+
 	rootCmd.SetVersionTemplate(`{{printf "inboxfewer version %s\n" .Version}}`)
 
 	// If no subcommand is provided, run the cleanup command by default

--- a/internal/google/oauth.go
+++ b/internal/google/oauth.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -16,31 +17,91 @@ import (
 	gmail "google.golang.org/api/gmail/v1"
 )
 
-// HasToken checks if a valid OAuth token exists
-func HasToken() bool {
+const defaultAccount = "default"
+
+// Account name validation regex: alphanumeric, hyphens, and underscores only
+var accountNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// MigrateDefaultToken migrates the old google.token to google-default.token if needed
+// This ensures backward compatibility for existing users
+func MigrateDefaultToken() error {
 	cacheDir := filepath.Join(userCacheDir(), "inboxfewer")
-	tokenFile := filepath.Join(cacheDir, "google.token")
+	oldTokenFile := filepath.Join(cacheDir, "google.token")
+	newTokenFile := getTokenFilePath(defaultAccount)
+
+	// Check if old token exists and new one doesn't
+	if _, err := os.Stat(oldTokenFile); err == nil {
+		if _, err := os.Stat(newTokenFile); os.IsNotExist(err) {
+			// Rename old token to new format
+			if err := os.Rename(oldTokenFile, newTokenFile); err != nil {
+				return fmt.Errorf("failed to migrate token file: %w", err)
+			}
+			log.Printf("Migrated google.token to google-default.token")
+		}
+	}
+
+	return nil
+}
+
+// getTokenFilePath returns the token file path for the given account
+func getTokenFilePath(account string) string {
+	cacheDir := filepath.Join(userCacheDir(), "inboxfewer")
+	return filepath.Join(cacheDir, fmt.Sprintf("google-%s.token", account))
+}
+
+// validateAccountName validates that the account name is acceptable
+func validateAccountName(account string) error {
+	if account == "" {
+		return fmt.Errorf("account name cannot be empty")
+	}
+	if !accountNameRegex.MatchString(account) {
+		return fmt.Errorf("account name must contain only alphanumeric characters, hyphens, and underscores")
+	}
+	return nil
+}
+
+// HasTokenForAccount checks if a valid OAuth token exists for the specified account
+func HasTokenForAccount(account string) bool {
+	if err := validateAccountName(account); err != nil {
+		return false
+	}
+	tokenFile := getTokenFilePath(account)
 	_, err := os.ReadFile(tokenFile)
 	return err == nil
 }
 
-// GetAuthURL returns the OAuth URL for user authorization
-func GetAuthURL() string {
-	conf := getOAuthConfig()
-	return conf.AuthCodeURL("state")
+// HasToken checks if a valid OAuth token exists for the default account
+func HasToken() bool {
+	return HasTokenForAccount(defaultAccount)
 }
 
-// SaveToken exchanges an authorization code for tokens and saves them
-func SaveToken(ctx context.Context, authCode string) error {
+// GetAuthURLForAccount returns the OAuth URL for user authorization for a specific account
+func GetAuthURLForAccount(account string) string {
+	conf := getOAuthConfig()
+	// Include account name in state for better user experience
+	return conf.AuthCodeURL(fmt.Sprintf("state-%s", account))
+}
+
+// GetAuthURL returns the OAuth URL for user authorization for the default account
+func GetAuthURL() string {
+	return GetAuthURLForAccount(defaultAccount)
+}
+
+// SaveTokenForAccount exchanges an authorization code for tokens and saves them for a specific account
+func SaveTokenForAccount(ctx context.Context, account string, authCode string) error {
+	if err := validateAccountName(account); err != nil {
+		return fmt.Errorf("invalid account name: %w", err)
+	}
+
 	conf := getOAuthConfig()
 
 	t, err := conf.Exchange(ctx, authCode)
 	if err != nil {
-		return fmt.Errorf("failed to exchange auth code: %w", err)
+		return fmt.Errorf("failed to exchange auth code for account %s: %w", account, err)
 	}
 
 	cacheDir := filepath.Join(userCacheDir(), "inboxfewer")
-	tokenFile := filepath.Join(cacheDir, "google.token")
+	tokenFile := getTokenFilePath(account)
 
 	if err := os.MkdirAll(cacheDir, 0700); err != nil {
 		return fmt.Errorf("failed to create cache directory: %w", err)
@@ -48,10 +109,16 @@ func SaveToken(ctx context.Context, authCode string) error {
 
 	tokenData := t.AccessToken + " " + t.RefreshToken
 	if err := os.WriteFile(tokenFile, []byte(tokenData), 0600); err != nil {
-		return fmt.Errorf("failed to write token file: %w", err)
+		return fmt.Errorf("failed to write token file for account %s: %w", account, err)
 	}
 
+	log.Printf("Saved OAuth token for account: %s", account)
 	return nil
+}
+
+// SaveToken exchanges an authorization code for tokens and saves them for the default account
+func SaveToken(ctx context.Context, authCode string) error {
+	return SaveTokenForAccount(ctx, defaultAccount, authCode)
 }
 
 // getOAuthConfig returns the OAuth2 configuration for all Google services
@@ -73,22 +140,24 @@ func getOAuthConfig() *oauth2.Config {
 	}
 }
 
-// GetTokenSource returns an OAuth2 token source for the stored token
+// GetTokenSourceForAccount returns an OAuth2 token source for the stored token for a specific account
 // Returns nil if no valid token exists
-func GetTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	conf := getOAuthConfig()
+func GetTokenSourceForAccount(ctx context.Context, account string) (oauth2.TokenSource, error) {
+	if err := validateAccountName(account); err != nil {
+		return nil, fmt.Errorf("invalid account name: %w", err)
+	}
 
-	cacheDir := filepath.Join(userCacheDir(), "inboxfewer")
-	tokenFile := filepath.Join(cacheDir, "google.token")
+	conf := getOAuthConfig()
+	tokenFile := getTokenFilePath(account)
 
 	slurp, err := os.ReadFile(tokenFile)
 	if err != nil {
-		return nil, fmt.Errorf("no valid Google OAuth token found")
+		return nil, fmt.Errorf("no valid Google OAuth token found for account %s", account)
 	}
 
 	f := strings.Fields(strings.TrimSpace(string(slurp)))
 	if len(f) != 2 {
-		return nil, fmt.Errorf("invalid token format")
+		return nil, fmt.Errorf("invalid token format for account %s", account)
 	}
 
 	ts := conf.TokenSource(ctx, &oauth2.Token{
@@ -100,17 +169,23 @@ func GetTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 
 	// Validate the token
 	if _, err := ts.Token(); err != nil {
-		log.Printf("Cached token invalid: %v", err)
-		return nil, fmt.Errorf("cached token is invalid: %w", err)
+		log.Printf("Cached token invalid for account %s: %v", account, err)
+		return nil, fmt.Errorf("cached token is invalid for account %s: %w", account, err)
 	}
 
 	return ts, nil
 }
 
-// GetHTTPClient returns an HTTP client configured with OAuth2 authentication
+// GetTokenSource returns an OAuth2 token source for the stored token for the default account
+// Returns nil if no valid token exists
+func GetTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	return GetTokenSourceForAccount(ctx, defaultAccount)
+}
+
+// GetHTTPClientForAccount returns an HTTP client configured with OAuth2 authentication for a specific account
 // The client is configured to use HTTP/1.1 to avoid HTTP/2 protocol errors
-func GetHTTPClient(ctx context.Context) (*http.Client, error) {
-	ts, err := GetTokenSource(ctx)
+func GetHTTPClientForAccount(ctx context.Context, account string) (*http.Client, error) {
+	ts, err := GetTokenSourceForAccount(ctx, account)
 	if err != nil {
 		return nil, err
 	}
@@ -125,6 +200,12 @@ func GetHTTPClient(ctx context.Context) (*http.Client, error) {
 	transport.Base = baseTransport
 
 	return client, nil
+}
+
+// GetHTTPClient returns an HTTP client configured with OAuth2 authentication for the default account
+// The client is configured to use HTTP/1.1 to avoid HTTP/2 protocol errors
+func GetHTTPClient(ctx context.Context) (*http.Client, error) {
+	return GetHTTPClientForAccount(ctx, defaultAccount)
 }
 
 func userCacheDir() string {

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -11,39 +11,44 @@ import (
 
 // ServerContext holds the context for the MCP server
 type ServerContext struct {
-	ctx         context.Context
-	cancel      context.CancelFunc
-	gmailClient *gmail.Client
-	docsClient  *docs.Client
-	githubUser  string
-	githubToken string
-	mu          sync.RWMutex
-	shutdown    bool
+	ctx          context.Context
+	cancel       context.CancelFunc
+	gmailClients map[string]*gmail.Client // Maps account name to Gmail client
+	docsClients  map[string]*docs.Client  // Maps account name to Docs client
+	githubUser   string
+	githubToken  string
+	mu           sync.RWMutex
+	shutdown     bool
 }
 
 // NewServerContext creates a new server context
 func NewServerContext(ctx context.Context, githubUser, githubToken string) (*ServerContext, error) {
 	shutdownCtx, cancel := context.WithCancel(ctx)
 
-	// Try to create Gmail client, but don't fail if token is missing
-	// Client will be lazily initialized when first needed
-	var gmailClient *gmail.Client
+	// Initialize client maps
+	gmailClients := make(map[string]*gmail.Client)
+	docsClients := make(map[string]*docs.Client)
+
+	// Try to create default Gmail client, but don't fail if token is missing
+	// Clients will be lazily initialized when first needed
 	if gmail.HasToken() {
-		var err error
-		gmailClient, err = gmail.NewClient(shutdownCtx)
+		gmailClient, err := gmail.NewClient(shutdownCtx)
 		if err != nil {
 			// Log but don't fail - will be re-attempted on first use
-			fmt.Printf("Warning: failed to create Gmail client: %v\n", err)
+			fmt.Printf("Warning: failed to create Gmail client for default account: %v\n", err)
+		} else {
+			gmailClients["default"] = gmailClient
 		}
 	}
 
 	return &ServerContext{
-		ctx:         shutdownCtx,
-		cancel:      cancel,
-		gmailClient: gmailClient,
-		githubUser:  githubUser,
-		githubToken: githubToken,
-		shutdown:    false,
+		ctx:          shutdownCtx,
+		cancel:       cancel,
+		gmailClients: gmailClients,
+		docsClients:  docsClients,
+		githubUser:   githubUser,
+		githubToken:  githubToken,
+		shutdown:     false,
 	}, nil
 }
 
@@ -52,32 +57,92 @@ func (sc *ServerContext) Context() context.Context {
 	return sc.ctx
 }
 
-// GmailClient returns the Gmail client (may be nil if not authenticated)
+// GmailClientForAccount returns the Gmail client for a specific account
+// Creates and caches the client if it doesn't exist yet
+// Returns nil if the account has no token
+func (sc *ServerContext) GmailClientForAccount(account string) *gmail.Client {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	// Check if client already exists
+	if client, ok := sc.gmailClients[account]; ok {
+		return client
+	}
+
+	// Try to create client if token exists
+	if !gmail.HasTokenForAccount(account) {
+		return nil
+	}
+
+	client, err := gmail.NewClientForAccount(sc.ctx, account)
+	if err != nil {
+		fmt.Printf("Warning: failed to create Gmail client for account %s: %v\n", account, err)
+		return nil
+	}
+
+	sc.gmailClients[account] = client
+	return client
+}
+
+// GmailClient returns the Gmail client for the default account
 func (sc *ServerContext) GmailClient() *gmail.Client {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
-	return sc.gmailClient
+	return sc.GmailClientForAccount("default")
 }
 
-// SetGmailClient sets the Gmail client
+// SetGmailClientForAccount sets the Gmail client for a specific account
+func (sc *ServerContext) SetGmailClientForAccount(account string, client *gmail.Client) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.gmailClients[account] = client
+}
+
+// SetGmailClient sets the Gmail client for the default account
 func (sc *ServerContext) SetGmailClient(client *gmail.Client) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	sc.gmailClient = client
+	sc.SetGmailClientForAccount("default", client)
 }
 
-// DocsClient returns the Docs client (lazy initialization)
+// DocsClientForAccount returns the Docs client for a specific account
+// Creates and caches the client if it doesn't exist yet
+// Returns nil if the account has no token
+func (sc *ServerContext) DocsClientForAccount(account string) *docs.Client {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	// Check if client already exists
+	if client, ok := sc.docsClients[account]; ok {
+		return client
+	}
+
+	// Try to create client if token exists
+	if !docs.HasTokenForAccount(account) {
+		return nil
+	}
+
+	client, err := docs.NewClientForAccount(sc.ctx, account)
+	if err != nil {
+		fmt.Printf("Warning: failed to create Docs client for account %s: %v\n", account, err)
+		return nil
+	}
+
+	sc.docsClients[account] = client
+	return client
+}
+
+// DocsClient returns the Docs client for the default account
 func (sc *ServerContext) DocsClient() *docs.Client {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
-	return sc.docsClient
+	return sc.DocsClientForAccount("default")
 }
 
-// SetDocsClient sets the Docs client
-func (sc *ServerContext) SetDocsClient(client *docs.Client) {
+// SetDocsClientForAccount sets the Docs client for a specific account
+func (sc *ServerContext) SetDocsClientForAccount(account string, client *docs.Client) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	sc.docsClient = client
+	sc.docsClients[account] = client
+}
+
+// SetDocsClient sets the Docs client for the default account
+func (sc *ServerContext) SetDocsClient(client *docs.Client) {
+	sc.SetDocsClientForAccount("default", client)
 }
 
 // GithubUser returns the GitHub username

--- a/internal/tools/gmail_tools/contact_tools.go
+++ b/internal/tools/gmail_tools/contact_tools.go
@@ -16,6 +16,9 @@ func RegisterContactTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	// Search contacts tool
 	searchContactsTool := mcp.NewTool("gmail_search_contacts",
 		mcp.WithDescription("Search for contacts in Google Contacts"),
+		mcp.WithString("account",
+			mcp.Description("Account name (default: 'default'). Used to manage multiple Google accounts."),
+		),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Search query to find contacts (e.g., name, email, phone number)"),
@@ -47,12 +50,13 @@ func handleSearchContacts(ctx context.Context, request mcp.CallToolRequest, sc *
 		}
 	}
 
-	// Get or create Gmail client
-	client := sc.GmailClient()
+	// Get or create Gmail client for the specified account
+	account := getAccountFromArgs(args)
+	client := sc.GmailClientForAccount(account)
 	if client == nil {
-		if !gmail.HasToken() {
-			authURL := gmail.GetAuthURL()
-			errorMsg := fmt.Sprintf(`Google OAuth token not found. To authorize access:
+		if !gmail.HasTokenForAccount(account) {
+			authURL := gmail.GetAuthURLForAccount(account)
+			errorMsg := fmt.Sprintf(`Google OAuth token not found for account "%s". To authorize access:
 
 1. Visit this URL in your browser:
    %s
@@ -62,18 +66,18 @@ func handleSearchContacts(ctx context.Context, request mcp.CallToolRequest, sc *
 4. Copy the authorization code
 
 5. Provide the authorization code to your AI agent
-   The agent will use the google_save_auth_code tool to complete authentication.
+   The agent will use the google_save_auth_code tool with account="%s" to complete authentication.
 
-Note: You only need to authorize once. The tokens will be automatically refreshed.`, authURL)
+Note: You only need to authorize once. The tokens will be automatically refreshed.`, account, authURL, account)
 			return mcp.NewToolResultError(errorMsg), nil
 		}
 
 		var err error
-		client, err = gmail.NewClient(ctx)
+		client, err = gmail.NewClientForAccount(ctx, account)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to create Gmail client: %v", err)), nil
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to create Gmail client for account %s: %v", account, err)), nil
 		}
-		sc.SetGmailClient(client)
+		sc.SetGmailClientForAccount(account, client)
 	}
 
 	contacts, err := client.SearchContacts(query, maxResults)


### PR DESCRIPTION
## Summary

Implements #14 - Adds comprehensive multi-account support allowing users to manage multiple Google accounts (work, personal, etc.) with per-operation account selection.

## Changes

### 🔐 Core OAuth Layer (Phase 1)
- Added account-aware OAuth functions to `internal/google/oauth.go`
- Token files stored per account: `~/.cache/inboxfewer/google-{account}.token`
- Automatic migration: `google.token` → `google-default.token`
- All legacy functions preserved for backward compatibility
- Comprehensive unit tests with >80% coverage

### 👥 Client Layer (Phase 2)
- Updated Gmail and Docs clients with `NewClientForAccount(ctx, account)`
- Added `Account()` method to track which account a client uses
- Account-aware wrapper functions in both clients
- Backward compatible: legacy functions work unchanged

### 🔄 Server Context (Phase 3)
- Multi-client support: `gmailClients` and `docsClients` maps
- Lazy initialization per account
- `GmailClientForAccount(account)` and `DocsClientForAccount(account)` methods
- Automatic client caching per account

### 🛠️ MCP Tools (Phase 4)
Added `account` parameter to all 15+ MCP tools:
- **OAuth tools**: `google_get_auth_url`, `google_save_auth_code`
- **Gmail tools** (11): list_threads, archive_thread, send_email, search_contacts, etc.
- **Docs tools** (2): get_document, get_document_metadata
- Default: `"default"` account if not specified

### 💻 CLI Commands (Phase 5)
- Added `--account` flag to `inboxfewer cleanup`
- Token migration in `cmd/root.go` Execute() function
- Default account: `"default"`
- Examples: `inboxfewer cleanup --account work`

### 📚 Documentation (Phase 6)
- Updated README.md with multi-account documentation
- Configuration section explains token storage
- CLI and MCP usage examples
- Migration and compatibility notes

## Key Features

✅ Support for unlimited Google accounts with unique names  
✅ Per-operation account selection (MCP tools and CLI)  
✅ Automatic token migration for existing users  
✅ Isolated token storage per account  
✅ OAuth flow triggered automatically for new accounts  
✅ Backward compatible - no breaking changes for existing code  
✅ Comprehensive documentation with examples  

## Testing

- ✅ All existing tests passing
- ✅ New unit tests for multi-account OAuth functionality
- ✅ Test coverage >80%
- ✅ Code formatted with `goimports` and `go fmt`
- ✅ No linter errors

## Migration

Existing users' tokens are automatically migrated from `google.token` to `google-default.token` on first run. No manual intervention required.

## Examples

### CLI
```bash
# Default account
inboxfewer cleanup

# Work account
inboxfewer cleanup --account work
```

### MCP Tools
```javascript
// OAuth for work account
google_get_auth_url({account: "work"})
google_save_auth_code({account: "work", authCode: "..."})

// Use work account
gmail_list_threads({account: "work", query: "in:inbox"})

// Use personal account
gmail_send_email({account: "personal", to: "friend@example.com", ...})
```

Closes #14