### PR TITLE
Fix gmail_get_message_bodies to accept Thread IDs

### DIFF
--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -176,6 +176,15 @@ func (c *Client) ForeachThread(q string, fn func(*gmail.Thread) error) error {
 	}
 }
 
+// GetThread retrieves a full Gmail thread with all its messages
+func (c *Client) GetThread(threadID string) (*gmail.Thread, error) {
+	thread, err := c.svc.Threads.Get("me", threadID).Format("full").Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get thread %s: %w", threadID, err)
+	}
+	return thread, nil
+}
+
 // PopulateThread populates t with its full data. t.Id must be set initially.
 func (c *Client) PopulateThread(t *gmail.Thread) error {
 	req := c.svc.Threads.Get("me", t.Id).Format("full")

--- a/internal/tools/gmail_tools/attachment_tools.go
+++ b/internal/tools/gmail_tools/attachment_tools.go
@@ -59,13 +59,13 @@ func RegisterAttachmentTools(s *mcpserver.MCPServer, sc *server.ServerContext) e
 
 	// Get message bodies tool
 	getMessageBodiesTool := mcp.NewTool("gmail_get_message_bodies",
-		mcp.WithDescription("Extract text or HTML body from one or more Gmail messages"),
+		mcp.WithDescription("Extract text or HTML body from one or more Gmail messages or threads. Accepts both Message IDs and Thread IDs."),
 		mcp.WithString("account",
 			mcp.Description("Account name (default: 'default'). Used to manage multiple Google accounts."),
 		),
 		mcp.WithString("messageIds",
 			mcp.Required(),
-			mcp.Description("Message ID (string) or array of message IDs"),
+			mcp.Description("Message ID or Thread ID (string) or array of IDs. Thread IDs will automatically fetch all messages in the thread."),
 		),
 		mcp.WithString("format",
 			mcp.Description("Body format: 'text' (default) or 'html'"),


### PR DESCRIPTION
Fixes #46

## Overview

This PR adds support for Thread IDs in the `gmail_get_message_bodies` tool, fixing the broken inbox review workflow.

## Problem

- `gmail_list_threads` returns Thread IDs
- `gmail_get_message_bodies` only accepted Message IDs  
- Using Thread IDs resulted in 404 errors
- This blocked the core inbox workflow

## Solution

Modified `GetMessageBody` to intelligently handle both ID types:
1. First tries as Message ID (most common, no extra API call)
2. On 404, automatically tries as Thread ID
3. Returns all messages in the thread with clear separators

## Implementation Details

### Added Functions
- `GetThread(threadID)` - Fetches full thread with all messages
- `GetThreadMessageBodies(threadID, format)` - Extracts all message bodies from thread
- `extractBodyFromMessage(msg, format)` - Common body extraction logic

### Modified Functions  
- `GetMessageBody(messageID, format)` - Now accepts both Message and Thread IDs

### Tests
- ✅ All existing tests pass
- ✅ Added comprehensive tests for new functionality
- ✅ Tests for text/html formats, multipart messages, edge cases

## Backward Compatibility

**100% backward compatible** - existing Message ID usage works exactly as before. Thread ID support is transparent and automatic.

## Example Usage

```go
// Works with Message IDs (as before)
body, _ := client.GetMessageBody("msg-123", "text")

// Now also works with Thread IDs (new)
body, _ := client.GetMessageBody("thread-456", "text")
// Returns: "Message 1/3 (ID: ...):\n\n<body1>\n\n---\n\nMessage 2/3..."
```

## Testing

```bash
make test
# All tests pass ✅
```