### PR TITLE
fix(ci): Handle existing tags and add manual Docker release trigger

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -75,9 +75,16 @@ jobs:
       - name: Create Tag
         run: |
           NEXT_VERSION="${{ steps.version.outputs.next_version }}"
-          git tag "$NEXT_VERSION"
-          git push origin "$NEXT_VERSION"
-          echo "Created and pushed tag $NEXT_VERSION"
+          # Check if tag already exists (locally or remotely)
+          if git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; then
+            echo "Tag $NEXT_VERSION already exists locally, skipping tag creation"
+          elif git ls-remote --tags origin | grep -q "refs/tags/$NEXT_VERSION$"; then
+            echo "Tag $NEXT_VERSION already exists on remote, skipping tag creation"
+          else
+            git tag "$NEXT_VERSION"
+            git push origin "$NEXT_VERSION"
+            echo "Created and pushed tag $NEXT_VERSION"
+          fi
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,12 @@
 name: Build and Push Docker Image (Release)
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g., v0.0.26). Leave empty to use latest tag.'
+        required: false
+        type: string
   workflow_run:
     workflows: ["Auto Release"]
     types:
@@ -15,7 +21,7 @@ env:
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -30,8 +36,14 @@ jobs:
       - name: Get latest release tag
         id: get_tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          echo "Latest release tag: $LATEST_TAG"
+          # Use input tag if provided (for manual workflow_dispatch), otherwise get latest
+          if [ -n "${{ inputs.tag }}" ]; then
+            LATEST_TAG="${{ inputs.tag }}"
+            echo "Using manually specified tag: $LATEST_TAG"
+          else
+            LATEST_TAG=$(git describe --tags --abbrev=0)
+            echo "Latest release tag: $LATEST_TAG"
+          fi
           echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

This PR fixes the CI/CD workflow issues that prevented Docker images from being built for releases.

## Problem

Docker images were never built for v0.0.26 because:
1. The `docker-release.yml` workflow was added in PR #57
2. When that PR was merged, Auto Release created v0.0.26
3. But the Docker Release workflow didn't exist on `main` yet when Auto Release started
4. The `workflow_run` trigger couldn't fire

## Changes

### Auto Release (`auto-release.yaml`)
- Skip tag creation if the tag already exists (locally or remotely)
- Prevents workflow failures on re-runs or race conditions

### Docker Release (`docker-release.yml`)
- Add `workflow_dispatch` trigger for manual builds
- Support optional `tag` input to build images for any release
- Update job condition to run on both manual dispatch and workflow_run

## Testing

After this PR is merged:
1. v0.0.27 will be created automatically with Docker images
2. You can also manually trigger Docker Release for v0.0.26 via GitHub Actions UI