### PR TITLE
Revert "fix(ci): Handle existing tags and add manual Docker release trigger (#58)"

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -75,16 +75,9 @@ jobs:
       - name: Create Tag
         run: |
           NEXT_VERSION="${{ steps.version.outputs.next_version }}"
-          # Check if tag already exists (locally or remotely)
-          if git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; then
-            echo "Tag $NEXT_VERSION already exists locally, skipping tag creation"
-          elif git ls-remote --tags origin | grep -q "refs/tags/$NEXT_VERSION$"; then
-            echo "Tag $NEXT_VERSION already exists on remote, skipping tag creation"
-          else
-            git tag "$NEXT_VERSION"
-            git push origin "$NEXT_VERSION"
-            echo "Created and pushed tag $NEXT_VERSION"
-          fi
+          git tag "$NEXT_VERSION"
+          git push origin "$NEXT_VERSION"
+          echo "Created and pushed tag $NEXT_VERSION"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,12 +1,6 @@
 name: Build and Push Docker Image (Release)
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to build (e.g., v0.0.26). Leave empty to use latest tag.'
-        required: false
-        type: string
   workflow_run:
     workflows: ["Auto Release"]
     types:
@@ -21,7 +15,7 @@ env:
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -36,14 +30,8 @@ jobs:
       - name: Get latest release tag
         id: get_tag
         run: |
-          # Use input tag if provided (for manual workflow_dispatch), otherwise get latest
-          if [ -n "${{ inputs.tag }}" ]; then
-            LATEST_TAG="${{ inputs.tag }}"
-            echo "Using manually specified tag: $LATEST_TAG"
-          else
-            LATEST_TAG=$(git describe --tags --abbrev=0)
-            echo "Latest release tag: $LATEST_TAG"
-          fi
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          echo "Latest release tag: $LATEST_TAG"
           echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Reverts the changes from PR #58 which broke the Auto Release workflow.

The tag existence check caused GoReleaser to fail when running against a commit that didn't match the detected tag.