### PR TITLE
fix(ci): Trigger Auto Release on push to main instead of PR merge

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,19 +1,16 @@
 ---
 name: Auto Release
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
 permissions:
   contents: write
-  pull-requests: read
 
 jobs:
   auto_release:
     name: Auto Release
-    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

When a PR is merged, the Auto Release workflow runs in the context of the PR's head branch (not main). This causes the Docker Release workflow to not trigger because it has a `branches: [main]` filter in its `workflow_run` trigger.

**Previous flow:**
1. PR merged → Auto Release runs on PR branch
2. Auto Release creates tag and release
3. Docker Release workflow NOT triggered (branch filter mismatch)
4. No Docker image built automatically

## Solution

Change Auto Release to trigger on `push` events to `main` instead of `pull_request` close events.

**New flow:**
1. PR merged → push to main
2. Auto Release runs on main branch
3. Auto Release creates tag and release  
4. Docker Release workflow triggered (branch matches)
5. Docker image built and pushed automatically

## Changes

- Changed trigger from `pull_request: types: [closed]` to `push: branches: [main]`
- Removed `if: github.event.pull_request.merged` condition (no longer needed)
- Removed `pull-requests: read` permission (no longer needed)

## Testing

After merging this PR:
- Auto Release should run on the push to main
- Create a new release with version bump
- Docker Release workflow should automatically trigger
- Multi-arch Docker images should be built and pushed to ghcr.io