### PR TITLE
fix(ci): Ensure Auto Release fetches all tags and handles duplicates

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -35,6 +35,9 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
       - name: Determine Next Version
         id: version
         run: |
@@ -72,6 +75,10 @@ jobs:
       - name: Create Tag
         run: |
           NEXT_VERSION="${{ steps.version.outputs.next_version }}"
+          if git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; then
+            echo "Tag $NEXT_VERSION already exists, skipping tag creation"
+            exit 1
+          fi
           git tag "$NEXT_VERSION"
           git push origin "$NEXT_VERSION"
           echo "Created and pushed tag $NEXT_VERSION"


### PR DESCRIPTION
## Problem

When PR #61 was merged, the Auto Release workflow failed with:
```
fatal: tag 'v0.0.28' already exists
```

This happened because:
1. The workflow checked out code with `fetch-depth: 0` but didn't explicitly fetch tags
2. When the workflow ran, it only saw v0.0.27 as the latest tag
3. It tried to create v0.0.28, which already existed from PR #60

## Root Causes

1. **Missing tag fetch**: Although `fetch-depth: 0` fetches all commits, it doesn't guarantee all tags are fetched, especially recent ones created between checkout and version determination
2. **No duplicate detection**: The workflow had no safety check to detect if a tag already exists before trying to create it

## Solution

### 1. Explicit Tag Fetching
Add a dedicated step to fetch all tags after Git configuration:
```yaml
- name: Fetch all tags
  run: git fetch --tags --force
```

### 2. Duplicate Tag Detection
Add a check before tag creation to fail gracefully if the tag already exists:
```bash
if git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; then
  echo "Tag $NEXT_VERSION already exists, skipping tag creation"
  exit 1
fi
```

## Testing

After merging this PR:
- Auto Release should correctly see v0.0.28 as the latest tag
- It should create v0.0.29
- Docker Release workflow should be triggered
- Multi-arch Docker images should be built

## Related

- PR #61 - Changed Auto Release to trigger on push to main
- PR #60 - Created release v0.0.28