### PR TITLE
fix(ci): Fetch tags from origin remote explicitly

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -36,7 +36,7 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Fetch all tags
-        run: git fetch --tags --force
+        run: git fetch origin --tags --force
 
       - name: Determine Next Version
         id: version


### PR DESCRIPTION
## Problem

After PR #62 was merged, the Auto Release workflow still failed with the same issue - it was seeing v0.0.27 as the latest tag instead of v0.0.28.

The root cause: The tag fetch command didn't specify the remote:
```bash
git fetch --tags --force
```

Without a remote specified, git doesn't actually fetch from origin.

## Solution

Explicitly specify the origin remote:
```bash
git fetch origin --tags --force
```

## Testing

After this PR is merged:
- Auto Release should correctly fetch v0.0.28 from origin
- It should create v0.0.29
- Docker Release workflow should be triggered
- Docker image should be built