### PR TITLE
fix(ci): Use git tag instead of git describe for version detection

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -42,7 +42,12 @@ jobs:
         id: version
         run: |
           set -e
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Use git tag with version sort instead of git describe
+          # git describe only finds tags reachable from HEAD, which fails for parallel branches
+          LATEST_TAG=$(git tag --sort=-version:refname | head -n1 || echo "v0.0.0")
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
           LATEST_VERSION=${LATEST_TAG#v}
           IFS='.' read -r -a VERSION_PARTS <<< "$LATEST_VERSION"
           NEXT_PATCH=$((VERSION_PARTS[2] + 1))


### PR DESCRIPTION
## Problem

After merging PRs #61, #62, and #63, the Auto Release workflow continued to fail because it couldn't find tag v0.0.28. The logs showed:
```
Latest tag: v0.0.27
Next version: v0.0.28
Tag v0.0.28 already exists, skipping tag creation
```

## Root Cause

The workflow used `git describe --tags --abbrev=0` to find the latest tag. However, this command only finds tags that are **reachable from the current HEAD commit**.

When:
1. PR #60 merged → created tag v0.0.28
2. PR #61/62/63 merged (from separate feature branches)
3. These commits weren't in the ancestry of v0.0.28
4. So `git describe` couldn't find v0.0.28

## Solution

Replace `git describe --tags --abbrev=0` with:
```bash
git tag --sort=-version:refname | head -n1
```

This command:
- Lists ALL tags (not just those reachable from HEAD)
- Sorts them by version number (not chronologically)
- Returns the highest version tag

## Testing

After this PR merges:
- Auto Release should find v0.0.28 as the latest tag
- It should create v0.0.29
- Docker Release workflow should trigger
- Multi-arch Docker image should be built and pushed