### PR TITLE
fix(ci): Use git tag instead of git describe in Docker Release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -30,7 +30,13 @@ jobs:
       - name: Get latest release tag
         id: get_tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          # Use git tag with version sort instead of git describe
+          # git describe only finds tags reachable from HEAD
+          LATEST_TAG=$(git tag --sort=-version:refname | head -n1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "Error: No tags found"
+            exit 1
+          fi
           echo "Latest release tag: $LATEST_TAG"
           echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

After PR #64 was merged and Auto Release successfully created v0.0.29, the Docker Release workflow failed with:
```
Downloading binaries for v0.0.27...
release not found
```

The workflow was trying to download binaries from v0.0.27 instead of v0.0.29.

## Root Cause

The Docker Release workflow uses the same flawed approach that was fixed in PR #64 for Auto Release:
```bash
LATEST_TAG=$(git describe --tags --abbrev=0)
```

This only finds tags reachable from the current HEAD commit, not the actual latest version tag.

## Solution

Apply the same fix from PR #64 - use `git tag` with version sorting:
```bash
LATEST_TAG=$(git tag --sort=-version:refname | head -n1)
```

## Testing

After this PR merges:
- A new push to main will trigger Auto Release (creating v0.0.30)
- Docker Release workflow should correctly find v0.0.30
- Multi-arch Docker images should be built and pushed to ghcr.io

## Related

- PR #64 - Fixed the same issue in Auto Release workflow