### PR TITLE
feat(chart): Add Gateway API support to Helm chart

### DIFF
--- a/charts/inboxfewer/Chart.yaml
+++ b/charts/inboxfewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inboxfewer
 description: A Helm chart for inboxfewer MCP server for Gmail and Google services integration
 type: application
-version: 0.1.1
+version: 0.1.2
 # appVersion is dynamically set at package time from the latest git tag by helm-release.yml
 # This value is only used for local development; CI overrides it with --app-version
 # Users can also override with: --set image.tag=v1.2.3

--- a/charts/inboxfewer/templates/backendtrafficpolicy.yaml
+++ b/charts/inboxfewer/templates/backendtrafficpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.backendTrafficPolicy.enabled -}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ include "inboxfewer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inboxfewer.labels" . | nindent 4 }}
+    {{- with .Values.gatewayAPI.backendTrafficPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayAPI.backendTrafficPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "inboxfewer.fullname" . }}
+  timeout:
+    http:
+      requestTimeout: {{ .Values.gatewayAPI.backendTrafficPolicy.timeout | quote }}
+{{- end }}

--- a/charts/inboxfewer/templates/httproute.yaml
+++ b/charts/inboxfewer/templates/httproute.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.gatewayAPI.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "inboxfewer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inboxfewer.labels" . | nindent 4 }}
+    {{- with .Values.gatewayAPI.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayAPI.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gatewayAPI.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gatewayAPI.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.gatewayAPI.httpRoute.rules }}
+    {{- range .Values.gatewayAPI.httpRoute.rules }}
+    - {{- if .matches }}
+      matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- if .timeouts }}
+      timeouts:
+        {{- toYaml .timeouts | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "inboxfewer.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+    {{- else }}
+    # Default rule: match all paths and forward to the service
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "inboxfewer.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/inboxfewer/values.yaml
+++ b/charts/inboxfewer/values.yaml
@@ -61,6 +61,63 @@ ingress:
   #    hosts:
   #      - inboxfewer.local
 
+# Gateway API Configuration
+# Gateway API is the successor to Ingress, providing more powerful and expressive routing.
+# Both Ingress and Gateway API can be enabled simultaneously for migration scenarios.
+gatewayAPI:
+  # Enable Gateway API HTTPRoute
+  enabled: false
+
+  # HTTPRoute configuration
+  httpRoute:
+    # Parent gateway references (required when enabled)
+    # Example:
+    #   parentRefs:
+    #     - name: internal
+    #       namespace: envoy-gateway-system
+    parentRefs: []
+
+    # Hostnames for the route
+    # Example:
+    #   hostnames:
+    #     - inboxfewer.example.com
+    hostnames: []
+
+    # Routing rules (optional, defaults to a single PathPrefix "/" rule)
+    # If not specified, a default rule matching "/" with PathPrefix is created
+    # Example:
+    #   rules:
+    #     - matches:
+    #         - path:
+    #             type: PathPrefix
+    #             value: /api
+    #       timeouts:
+    #         request: 30s
+    rules: []
+
+    # Additional annotations for the HTTPRoute
+    annotations: {}
+
+    # Additional labels for the HTTPRoute
+    labels: {}
+
+  # BackendTrafficPolicy for Envoy Gateway (optional)
+  # Provides timeout and retry configuration at the backend level
+  # This is specific to Envoy Gateway - other implementations may use different CRDs
+  backendTrafficPolicy:
+    # Enable BackendTrafficPolicy creation
+    enabled: false
+
+    # Request timeout (e.g., "300s", "5m")
+    # MCP sessions can be long-running, so a longer timeout is recommended
+    timeout: "300s"
+
+    # Additional annotations for the BackendTrafficPolicy
+    annotations: {}
+
+    # Additional labels for the BackendTrafficPolicy
+    labels: {}
+
 resources:
   limits:
     cpu: 500m


### PR DESCRIPTION
## Summary

Add optional Gateway API (HTTPRoute) configuration to the Helm chart, allowing users to expose the service using Gateway API instead of or alongside traditional Ingress resources.

## Background

Gateway API is the successor to Ingress in Kubernetes, providing more powerful and expressive routing capabilities. Many clusters are migrating from ingress-nginx to Gateway API implementations like Envoy Gateway, Cilium Gateway, or others.

Currently, the chart only supports Ingress resources, requiring users to maintain separate HTTPRoute manifests outside the chart.

## Changes

- **values.yaml**: Add `gatewayAPI` section with:
  - `httpRoute` configuration (parentRefs, hostnames, rules, annotations, labels)
  - `backendTrafficPolicy` for Envoy Gateway timeout configuration

- **templates/httproute.yaml**: New HTTPRoute template
  - Renders Gateway API v1 HTTPRoute when `gatewayAPI.enabled: true`
  - Supports custom parentRefs, hostnames, and routing rules
  - Default rule matches all paths (PathPrefix /)

- **templates/backendtrafficpolicy.yaml**: New BackendTrafficPolicy template
  - Optional Envoy Gateway-specific CRD for timeout configuration
  - Default 300s timeout for long-running MCP sessions

- **README.md**: Updated with Gateway API documentation
  - Configuration parameter table
  - Example usage with Envoy Gateway
  - Note about migration scenarios

- **Chart.yaml**: Bumped version to 0.1.2

## Testing

- All helm lint checks pass
- Template rendering verified with Gateway API enabled/disabled
- Both Ingress and Gateway API can be enabled simultaneously (migration scenarios)
- Full test suite passes

Closes #81