### PR TITLE
fix(deps): update mcp-oauth to v0.2.36 for ForceConsent support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/teemow/inboxfewer
 go 1.25.4
 
 require (
-	github.com/giantswarm/mcp-oauth v0.2.33
+	github.com/giantswarm/mcp-oauth v0.2.36
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/giantswarm/mcp-oauth v0.2.33 h1:FVLM/pDsy0o3w8jzudt1kGFh5IetDyPHAjWhbBQ6Mnw=
-github.com/giantswarm/mcp-oauth v0.2.33/go.mod h1:zMd9aKfJWL/jR+ZKPbWr9itFFJpggn60UU+kQ7wwWBs=
+github.com/giantswarm/mcp-oauth v0.2.36 h1:4wEyafQNZzvp1/JDUwEZmRpnzFGc4zr6uLaS942t1L0=
+github.com/giantswarm/mcp-oauth v0.2.36/go.mod h1:zMd9aKfJWL/jR+ZKPbWr9itFFJpggn60UU+kQ7wwWBs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary

Updates mcp-oauth from v0.2.33 to v0.2.36 to get the ForceConsent feature for the Google OAuth provider.

## Problem

When using the Google OAuth provider, refresh tokens are not reliably returned after the initial authorization. This causes token refresh to fail with:

```
oauth2: token expired and refresh token is not set
```

**Root Cause**: Google only sends a refresh token on the **first consent**. Subsequent logins (when the user has already granted consent) do not include a refresh token in the response. This means users get logged out unexpectedly.

## Solution

The mcp-oauth v0.2.36 release adds `ForceConsent` configuration option to the Google provider. When enabled (the new default), it adds `prompt=consent` to the authorization URL. This forces the consent screen on every authorization, ensuring Google always returns a refresh token.

## Changes

- Updated `github.com/giantswarm/mcp-oauth` from v0.2.33 to v0.2.36

## Backward Compatibility

No breaking changes. The ForceConsent option defaults to `true` in v0.2.36, so existing deployments will automatically benefit from reliable refresh tokens.

## References

- [mcp-oauth v0.2.36 release](https://github.com/giantswarm/mcp-oauth/releases/tag/v0.2.36)
- [PR #169: Add ForceConsent option](https://github.com/giantswarm/mcp-oauth/pull/169)
- [Google OAuth 2.0 refresh token docs](https://developers.google.com/identity/protocols/oauth2/web-server#offline)