### PR TITLE
feat(helm): align Gateway API implementation with mcp-kubernetes

### DIFF
--- a/charts/inboxfewer/templates/httproute.yaml
+++ b/charts/inboxfewer/templates/httproute.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.gatewayAPI.enabled -}}
+{{- if not .Values.gatewayAPI.httpRoute.parentRefs }}
+{{- fail "gatewayAPI.httpRoute.parentRefs is required when gatewayAPI.enabled is true. Specify at least one parent Gateway reference." }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -33,6 +36,10 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
       {{- end }}
       {{- if .timeouts }}
       timeouts:

--- a/charts/inboxfewer/tests/gateway_api_test.yaml
+++ b/charts/inboxfewer/tests/gateway_api_test.yaml
@@ -1,0 +1,340 @@
+suite: Gateway API Tests
+templates:
+  - templates/httproute.yaml
+  - templates/backendtrafficpolicy.yaml
+tests:
+  #
+  # HTTPRoute Tests
+  #
+
+  - it: should not render HTTPRoute when gatewayAPI is disabled
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when parentRefs is empty with gatewayAPI enabled
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.httpRoute.parentRefs is required when gatewayAPI.enabled is true. Specify at least one parent Gateway reference."
+
+  - it: should render HTTPRoute with valid parentRefs
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+              namespace: envoy-gateway-system
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+
+  - it: should set parentRefs correctly
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+              namespace: envoy-gateway-system
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: internal
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: envoy-gateway-system
+
+  - it: should set hostnames when provided
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+          hostnames:
+            - example.com
+            - api.example.com
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: api.example.com
+
+  - it: should create default rule when no rules provided
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should apply custom rules with matches
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+          rules:
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /api
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /api
+
+  - it: should apply filters when provided
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+          rules:
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /
+              filters:
+                - type: RequestHeaderModifier
+                  requestHeaderModifier:
+                    add:
+                      - name: X-Custom-Header
+                        value: custom-value
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.add[0].name
+          value: X-Custom-Header
+
+  - it: should apply timeouts when provided
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+          rules:
+            - timeouts:
+                request: 30s
+    asserts:
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 30s
+
+  - it: should include standard labels
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+    asserts:
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/name"]
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/instance"]
+
+  - it: should apply custom labels to HTTPRoute
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+          labels:
+            custom-label: custom-value
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: custom-value
+
+  - it: should apply custom annotations to HTTPRoute
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+          annotations:
+            custom-annotation: annotation-value
+    asserts:
+      - equal:
+          path: metadata.annotations["custom-annotation"]
+          value: annotation-value
+
+  - it: should reference correct service port in backendRefs
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+      service:
+        port: 9000
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9000
+
+  #
+  # BackendTrafficPolicy Tests
+  #
+
+  - it: should not render BackendTrafficPolicy when gatewayAPI is disabled
+    template: templates/backendtrafficpolicy.yaml
+    set:
+      gatewayAPI:
+        enabled: false
+        backendTrafficPolicy:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render BackendTrafficPolicy when backendTrafficPolicy is disabled
+    template: templates/backendtrafficpolicy.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+        backendTrafficPolicy:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render BackendTrafficPolicy when both flags are enabled
+    template: templates/backendtrafficpolicy.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+        backendTrafficPolicy:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: BackendTrafficPolicy
+      - isAPIVersion:
+          of: gateway.envoyproxy.io/v1alpha1
+
+  - it: should set timeout correctly in BackendTrafficPolicy
+    template: templates/backendtrafficpolicy.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+        backendTrafficPolicy:
+          enabled: true
+          timeout: "600s"
+    asserts:
+      - equal:
+          path: spec.timeout.http.requestTimeout
+          value: "600s"
+
+  - it: should target the HTTPRoute in BackendTrafficPolicy
+    template: templates/backendtrafficpolicy.yaml
+    release:
+      name: my-release
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+        backendTrafficPolicy:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.targetRefs[0].group
+          value: gateway.networking.k8s.io
+      - equal:
+          path: spec.targetRefs[0].kind
+          value: HTTPRoute
+      - equal:
+          path: spec.targetRefs[0].name
+          value: my-release-inboxfewer
+
+  - it: should apply custom labels to BackendTrafficPolicy
+    template: templates/backendtrafficpolicy.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+        backendTrafficPolicy:
+          enabled: true
+          labels:
+            custom-label: btp-value
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: btp-value
+
+  - it: should apply custom annotations to BackendTrafficPolicy
+    template: templates/backendtrafficpolicy.yaml
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: internal
+        backendTrafficPolicy:
+          enabled: true
+          annotations:
+            custom-annotation: btp-annotation
+    asserts:
+      - equal:
+          path: metadata.annotations["custom-annotation"]
+          value: btp-annotation

--- a/charts/inboxfewer/values.schema.json
+++ b/charts/inboxfewer/values.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Gateway API configuration for HTTPRoute and BackendTrafficPolicy",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Gateway API HTTPRoute creation",
+          "default": false
+        },
+        "httpRoute": {
+          "type": "object",
+          "description": "HTTPRoute configuration",
+          "properties": {
+            "parentRefs": {
+              "type": "array",
+              "description": "Parent gateway references (required when gatewayAPI.enabled is true)",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the parent Gateway"
+                  },
+                  "namespace": {
+                    "type": "string",
+                    "description": "Namespace of the parent Gateway"
+                  },
+                  "sectionName": {
+                    "type": "string",
+                    "description": "SectionName is the name of a section within the target Gateway"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "description": "Port is the network port to match"
+                  }
+                },
+                "required": ["name"]
+              }
+            },
+            "hostnames": {
+              "type": "array",
+              "description": "Hostnames for the route",
+              "items": {
+                "type": "string"
+              }
+            },
+            "rules": {
+              "type": "array",
+              "description": "Routing rules (optional, defaults to a single PathPrefix '/' rule)",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "matches": {
+                    "type": "array",
+                    "description": "Match conditions for the rule",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "path": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": ["Exact", "PathPrefix", "RegularExpression"]
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "headers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "queryParams": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "method": {
+                          "type": "string",
+                          "enum": ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"]
+                        }
+                      }
+                    }
+                  },
+                  "filters": {
+                    "type": "array",
+                    "description": "Filters for request/response modification",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Filter type (e.g., RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, URLRewrite)"
+                        },
+                        "requestHeaderModifier": {
+                          "type": "object"
+                        },
+                        "responseHeaderModifier": {
+                          "type": "object"
+                        },
+                        "requestRedirect": {
+                          "type": "object"
+                        },
+                        "urlRewrite": {
+                          "type": "object"
+                        },
+                        "requestMirror": {
+                          "type": "object"
+                        },
+                        "extensionRef": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  },
+                  "timeouts": {
+                    "type": "object",
+                    "description": "Timeout configuration for the rule",
+                    "properties": {
+                      "request": {
+                        "type": "string",
+                        "description": "Request timeout (e.g., '30s', '5m')"
+                      },
+                      "backendRequest": {
+                        "type": "string",
+                        "description": "Backend request timeout"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Additional annotations for the HTTPRoute",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for the HTTPRoute",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "backendTrafficPolicy": {
+          "type": "object",
+          "description": "BackendTrafficPolicy for Envoy Gateway (optional)",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable BackendTrafficPolicy creation (requires gatewayAPI.enabled to also be true)",
+              "default": false
+            },
+            "timeout": {
+              "type": "string",
+              "description": "Request timeout (e.g., '300s', '5m')",
+              "default": "300s"
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Additional annotations for the BackendTrafficPolicy",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for the BackendTrafficPolicy",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/inboxfewer/values.yaml
+++ b/charts/inboxfewer/values.yaml
@@ -91,6 +91,12 @@ gatewayAPI:
     #         - path:
     #             type: PathPrefix
     #             value: /api
+    #       filters:
+    #         - type: RequestHeaderModifier
+    #           requestHeaderModifier:
+    #             add:
+    #               - name: X-Custom-Header
+    #                 value: custom-value
     #       timeouts:
     #         request: 30s
     rules: []


### PR DESCRIPTION
## Summary

Aligns the Gateway API implementation with mcp-kubernetes and muster to ensure consistency across Helm charts.

## Changes

### 1. Add parentRefs Validation

Added validation in `httproute.yaml` that fails early if `parentRefs` is empty when Gateway API is enabled:

```yaml
{{- if not .Values.gatewayAPI.httpRoute.parentRefs }}
{{- fail "gatewayAPI.httpRoute.parentRefs is required when gatewayAPI.enabled is true. Specify at least one parent Gateway reference." }}
{{- end }}
```

This provides better user feedback instead of creating an invalid HTTPRoute.

### 2. Add Filters Support to Custom Rules

Added `.filters` support for request/response modification in custom rules:

```yaml
{{- if .filters }}
filters:
  {{- toYaml .filters | nindent 8 }}
{{- end }}
```

### 3. Add values.schema.json Validation

Added a `gatewayAPI` section to `values.schema.json` for Helm value validation, including:
- HTTPRoute configuration (parentRefs, hostnames, rules, filters, timeouts)
- BackendTrafficPolicy configuration (enabled, timeout, labels, annotations)

### 4. Add Helm Unit Tests

Added 20 comprehensive tests in `tests/gateway_api_test.yaml` covering:
- HTTPRoute creation/conditional rendering
- parentRefs validation (fails when empty)
- BackendTrafficPolicy dual-flag requirement
- Filters support
- Timeouts configuration
- Service reference validation
- Labels/annotations inheritance

## Why This Matters

Consistent Gateway API configuration across charts makes it easier for users deploying multiple services to use the same values structure.

## Test Results

```
Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       20 passed, 20 total
```

Closes #98