### PR TITLE
fix(oauth): Fix SSO token forwarding with mcp-oauth v0.2.40

### DIFF
--- a/charts/inboxfewer/templates/deployment.yaml
+++ b/charts/inboxfewer/templates/deployment.yaml
@@ -193,7 +193,7 @@ spec:
           - name: OAUTH_TRUSTED_AUDIENCES
             value: {{ .Values.oauthSecurity.trustedAudiences | join "," | quote }}
           {{- end }}
-          {{- /* SSO Security (mcp-oauth v0.2.39+) */ -}}
+          {{- /* SSO Security (mcp-oauth v0.2.40+) */ -}}
           {{- if and .Values.oauthSecurity.sso .Values.oauthSecurity.sso.allowPrivateIPs }}
           - name: SSO_ALLOW_PRIVATE_IPS
             value: "true"

--- a/charts/inboxfewer/values.schema.json
+++ b/charts/inboxfewer/values.schema.json
@@ -928,12 +928,12 @@
         },
         "sso": {
           "type": "object",
-          "description": "SSO security configuration (mcp-oauth v0.2.39+)",
+          "description": "SSO security configuration (mcp-oauth v0.2.40+)",
           "additionalProperties": false,
           "properties": {
             "allowPrivateIPs": {
               "type": "boolean",
-              "description": "Allow JWKS endpoints to resolve to private IPs during SSO token validation. Required for private IdP deployments (e.g., Dex on internal networks). WARNING: reduces SSRF protection. Has no effect for Google OAuth (JWKS is always public). Note: Requires future mcp-oauth support for AllowPrivateIPJWKS.",
+              "description": "Allow JWKS endpoints to resolve to private IPs during SSO token validation. Required for private IdP deployments (e.g., Dex on internal networks). WARNING: reduces SSRF protection. Has no effect for Google OAuth (JWKS is always public).",
               "default": false
             }
           }

--- a/charts/inboxfewer/values.yaml
+++ b/charts/inboxfewer/values.yaml
@@ -375,7 +375,7 @@ oauthSecurity:
   # Default: [] (only accept tokens issued directly to this server's client_id)
   trustedAudiences: []
 
-  # SSO Security Configuration (mcp-oauth v0.2.39+)
+  # SSO Security Configuration (mcp-oauth v0.2.40+)
   sso:
     # Allow JWKS endpoints to resolve to private IP addresses during SSO token validation.
     # This is necessary for private/internal deployments where the IdP (e.g., Dex)
@@ -387,11 +387,6 @@ oauthSecurity:
     # Note: For Google OAuth, this setting has no effect as Google's JWKS endpoint
     # (https://www.googleapis.com/oauth2/v3/certs) is always publicly accessible.
     # This option is primarily for private Dex deployments.
-    #
-    # IMPORTANT: This configuration option is prepared for future mcp-oauth support.
-    # As of mcp-oauth v0.2.39, the library doesn't yet expose AllowPrivateIPJWKS.
-    # The value is stored for when mcp-oauth adds this capability.
-    # See: https://github.com/giantswarm/mcp-oauth/issues/175 (pending feature request)
     #
     # Default: false (blocked for security - SSRF protection enabled)
     allowPrivateIPs: false

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -69,7 +69,7 @@ type OAuthSecurityConfig struct {
 	// SSO Token Forwarding (mcp-oauth v0.2.38+)
 	TrustedAudiences []string
 
-	// SSO Security (mcp-oauth v0.2.39+)
+	// SSO Security (mcp-oauth v0.2.40+)
 	// Allows JWKS endpoints to resolve to private IPs for private IdP deployments
 	SSOAllowPrivateIPs bool
 
@@ -154,7 +154,7 @@ func newServeCmd() *cobra.Command {
 		cimdAllowPrivateIPs bool
 		// SSO Token Forwarding (mcp-oauth v0.2.38+)
 		trustedAudiences []string
-		// SSO Security (mcp-oauth v0.2.39+)
+		// SSO Security (mcp-oauth v0.2.40+)
 		ssoAllowPrivateIPs bool
 		// TLS/HTTPS support
 		tlsCertFile string
@@ -260,7 +260,7 @@ OAuth Configuration:
 				CIMDAllowPrivateIPs: cimdAllowPrivateIPs,
 				// SSO Token Forwarding (mcp-oauth v0.2.38+)
 				TrustedAudiences: trustedAudiences,
-				// SSO Security (mcp-oauth v0.2.39+)
+				// SSO Security (mcp-oauth v0.2.40+)
 				SSOAllowPrivateIPs: ssoAllowPrivateIPs,
 				// TLS support
 				TLSCertFile: tlsCertFile,
@@ -519,7 +519,7 @@ func runServe(transport string, debugMode bool, httpAddr string, yolo bool, goog
 		}
 	}
 
-	// Parse SSO private IP setting from environment variable (mcp-oauth v0.2.39+)
+	// Parse SSO private IP setting from environment variable (mcp-oauth v0.2.40+)
 	if !securityConfig.SSOAllowPrivateIPs {
 		if envVal := os.Getenv("SSO_ALLOW_PRIVATE_IPS"); envVal != "" {
 			if parsed, err := strconv.ParseBool(envVal); err == nil {
@@ -769,7 +769,7 @@ func runStreamableHTTPServer(mcpSrv *mcpserver.MCPServer, oldServerContext *serv
 		CIMDAllowPrivateIPs: securityConfig.CIMDAllowPrivateIPs,
 		// SSO Token Forwarding (mcp-oauth v0.2.38+)
 		TrustedAudiences: securityConfig.TrustedAudiences,
-		// SSO Security (mcp-oauth v0.2.39+)
+		// SSO Security (mcp-oauth v0.2.40+)
 		SSOAllowPrivateIPs: securityConfig.SSOAllowPrivateIPs,
 		// Storage configuration (mcp-oauth v0.2.30+)
 		Storage: oauth.StorageConfig{

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -1270,7 +1270,7 @@ oauthSecurity:
     - "muster-client"
     - "my-aggregator-client"
 
-  # SSO Security Configuration (mcp-oauth v0.2.39+)
+  # SSO Security Configuration (mcp-oauth v0.2.40+)
   sso:
     # Allow JWKS endpoints to resolve to private IPs
     # Required for private Dex deployments on internal networks
@@ -1297,7 +1297,7 @@ oauthSecurity:
 
 **Note:** For Google OAuth, this setting has no effect because Google's JWKS endpoint (`https://www.googleapis.com/oauth2/v3/certs`) is always publicly accessible.
 
-**Status:** This configuration option requires mcp-oauth to add `AllowPrivateIPJWKS` support. See [mcp-oauth#175](https://github.com/giantswarm/mcp-oauth/issues/175). The value is stored for when this capability is available.
+**Availability:** This feature requires mcp-oauth v0.2.40 or later.
 
 ### Security Model
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/teemow/inboxfewer
 go 1.25.4
 
 require (
-	github.com/giantswarm/mcp-oauth v0.2.39
+	github.com/giantswarm/mcp-oauth v0.2.40
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/giantswarm/mcp-oauth v0.2.39 h1:fE+zM3XuCW7RQ65xxvJJYubu+k8WpR+6pitTUHZxsgI=
-github.com/giantswarm/mcp-oauth v0.2.39/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
+github.com/giantswarm/mcp-oauth v0.2.40 h1:LBiiLFloBtvVinsKUXSNvlKXmA9c0vEgxyOJNLr5YiE=
+github.com/giantswarm/mcp-oauth v0.2.40/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/mcp/oauth/handler.go
+++ b/internal/mcp/oauth/handler.go
@@ -88,8 +88,8 @@ type Config struct {
 	TrustedAudiences []string
 
 	// SSOAllowPrivateIPs allows JWKS endpoints to resolve to private IP addresses
-	// during SSO token validation. This is necessary for private/internal deployments
-	// where the IdP (e.g., Dex) runs on a private network.
+	// during SSO token validation (mcp-oauth v0.2.40+). This is necessary for
+	// private/internal deployments where the IdP (e.g., Dex) runs on a private network.
 	//
 	// WARNING: Reduces SSRF protection. Only enable for internal/VPN deployments
 	// where the IdP legitimately runs on private networks (10.0.0.0/8, 172.16.0.0/12,
@@ -448,6 +448,10 @@ func NewHandler(config *Config) (*Handler, error) {
 		// SSO token forwarding (mcp-oauth v0.2.38+)
 		// Accept tokens with audiences from trusted upstream aggregators
 		TrustedAudiences: config.TrustedAudiences,
+
+		// Allow JWKS endpoints to resolve to private IPs (mcp-oauth v0.2.40+)
+		// Required for private IdP deployments (e.g., Dex on internal networks)
+		AllowPrivateIPJWKS: config.SSOAllowPrivateIPs,
 	}
 
 	// Configure interstitial page branding if provided


### PR DESCRIPTION
## Summary

Fixes #97 by updating mcp-oauth to v0.2.40 which resolves the SSO token forwarding bug and adds `AllowPrivateIPJWKS` support.

## Problem

When inboxfewer is configured with `trustedAudiences` to accept SSO tokens from an upstream MCP aggregator (like muster), the forwarded ID tokens were rejected with 401 because:

1. Upstream server forwards ID token as Bearer token
2. mcp-oauth calls Google userinfo to validate
3. Google returns 401 (userinfo requires ACCESS tokens, not ID tokens)
4. Request fails despite valid TrustedAudiences configuration

## Solution

mcp-oauth v0.2.39 (PR #174) fixes this by implementing JWKS-based JWT validation:

1. Detect if the Bearer token is a JWT (3 dot-separated parts)
2. If TrustedAudiences configured, validate JWT signature using provider's JWKS
3. Validate issuer matches provider
4. Check audience in TrustedAudiences
5. Extract user info from JWT claims (no userinfo call needed)
6. Fall back to userinfo only if JWT validation fails

mcp-oauth v0.2.40 (PR #176) adds `AllowPrivateIPJWKS` support for private IdP deployments.

## Changes

### Dependency Update
- mcp-oauth v0.2.38 -> v0.2.40

### New Configuration: `SSOAllowPrivateIPs` (Now Functional!)

Configuration option to support private IdP deployments (e.g., Dex on internal networks):

```yaml
oauthSecurity:
  trustedAudiences:
    - "upstream-client-id"
  sso:
    allowPrivateIPs: true  # Enable for private Dex deployments
```

This is now fully functional with mcp-oauth v0.2.40!

### Runtime Warnings

Added operator-friendly runtime warnings:
- **Separate info log for SSO private IP configuration** - makes log filtering easier

### Files Changed
- `go.mod`, `go.sum`: Dependency update to v0.2.40
- `internal/mcp/oauth/handler.go`: Add `SSOAllowPrivateIPs` config, wire to `AllowPrivateIPJWKS`
- `internal/server/oauth_http.go`: Wire config to handler
- `cmd/serve.go`: Add flag/env var (`SSO_ALLOW_PRIVATE_IPS`) + separate logging
- `charts/inboxfewer/templates/deployment.yaml`: Add env var
- `charts/inboxfewer/values.yaml`: Add `oauthSecurity.sso.allowPrivateIPs`
- `charts/inboxfewer/values.schema.json`: Add schema
- `docs/mcp-oauth.md`: Document JWKS validation and private IdP config

## Testing

- All existing tests pass
- mcp-oauth v0.2.40 includes comprehensive tests for JWKS validation

## Related Issues

- mcp-oauth#173: Original bug report  
- mcp-oauth#174: Fix PR for JWKS validation (merged)
- mcp-oauth#175: Feature request for AllowPrivateIPJWKS (closed - fixed in #176)
- mcp-oauth#176: Add AllowPrivateIPJWKS (merged in v0.2.40)
- Aligned with giantswarm/mcp-kubernetes#225