### PR TITLE
feat(oauth): Add SSO access token forwarding for Google API access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/teemow/inboxfewer
 go 1.25.4
 
 require (
-	github.com/giantswarm/mcp-oauth v0.2.40
+	github.com/giantswarm/mcp-oauth v0.2.45
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/giantswarm/mcp-oauth v0.2.40 h1:LBiiLFloBtvVinsKUXSNvlKXmA9c0vEgxyOJNLr5YiE=
 github.com/giantswarm/mcp-oauth v0.2.40/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
+github.com/giantswarm/mcp-oauth v0.2.45 h1:UCCIvADJntwalv5QkFqIFxxR9JROH8jpheor/q+PIRY=
+github.com/giantswarm/mcp-oauth v0.2.45/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/mcp/oauth/sso_access_token.go
+++ b/internal/mcp/oauth/sso_access_token.go
@@ -1,0 +1,245 @@
+package oauth
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+
+	"github.com/teemow/inboxfewer/internal/instrumentation"
+)
+
+const (
+	// SSOAccessTokenHeader is the HTTP header name for forwarded Google access tokens.
+	// When SSO token forwarding is enabled, the upstream aggregator (e.g., muster) forwards
+	// the user's Google access token in this header alongside the ID token in the
+	// Authorization header.
+	//
+	// The ID token proves identity (validated via TrustedAudiences/JWKS),
+	// while the access token provides Google API access with the required scopes.
+	SSOAccessTokenHeader = "X-Google-Access-Token"
+
+	// SSORefreshTokenHeader is the optional HTTP header name for forwarded Google refresh tokens.
+	// If provided, enables automatic token refresh for long-running sessions.
+	SSORefreshTokenHeader = "X-Google-Refresh-Token"
+
+	// SSOTokenExpiryHeader is the optional HTTP header name for the access token expiry time.
+	// Expected format: RFC3339 (e.g., "2024-01-20T15:04:05Z")
+	// If not provided, a default expiry of 1 hour is assumed.
+	SSOTokenExpiryHeader = "X-Google-Token-Expiry"
+
+	// defaultAccessTokenExpiry is the default expiry duration for access tokens
+	// when no expiry header is provided. Google access tokens typically expire in 1 hour.
+	defaultAccessTokenExpiry = 1 * time.Hour
+
+	// tokenStoreTimeout is the timeout for storing tokens in the token store.
+	tokenStoreTimeout = 5 * time.Second
+)
+
+// SSOMetricsRecorder is an interface for recording SSO token injection metrics.
+// This allows the middleware to record metrics without directly depending on the full Metrics type.
+type SSOMetricsRecorder interface {
+	RecordSSOTokenInjection(ctx context.Context, result string)
+}
+
+// SSOMiddlewareConfig holds configuration for the SSO access token middleware.
+type SSOMiddlewareConfig struct {
+	// Store is the token store to save forwarded access tokens
+	Store storage.TokenStore
+
+	// Logger for audit and debug logging (optional, uses slog.Default if nil)
+	Logger *slog.Logger
+
+	// Metrics for recording SSO token injection metrics (optional)
+	Metrics SSOMetricsRecorder
+}
+
+// SSOAccessTokenMiddleware creates middleware that extracts and stores forwarded Google access tokens.
+// This middleware should wrap handlers that are already protected by OAuth validation.
+//
+// When SSO token forwarding is enabled:
+//  1. The upstream aggregator (e.g., muster) validates the user with Google OAuth
+//  2. The aggregator forwards the ID token in the Authorization header (validated by TrustedAudiences)
+//  3. The aggregator forwards the access token in X-Google-Access-Token header
+//  4. This middleware extracts the access token, stores it for Google API calls, and injects it into context
+//
+// The middleware processes the access token if:
+//   - The user was authenticated (user info present in context from OAuth middleware)
+//   - The X-Google-Access-Token header is present and non-empty
+//
+// Token Handling:
+//   - SSO flow (userInfo.IsSSO() == true): Token is injected into context AND stored
+//   - Non-SSO flow: Token is stored only (for compatibility)
+//
+// Parameters:
+//   - store: The token store to save forwarded access tokens
+//   - logger: Logger for audit and debug logging (optional, uses slog.Default if nil)
+func SSOAccessTokenMiddleware(store storage.TokenStore, logger *slog.Logger) func(http.Handler) http.Handler {
+	return SSOAccessTokenMiddlewareWithConfig(&SSOMiddlewareConfig{
+		Store:  store,
+		Logger: logger,
+	})
+}
+
+// SSOAccessTokenMiddlewareWithConfig creates middleware with full configuration including metrics.
+// This is the preferred way to create the middleware when metrics are available.
+func SSOAccessTokenMiddlewareWithConfig(config *SSOMiddlewareConfig) func(http.Handler) http.Handler {
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Helper to record metrics if configured
+	recordMetric := func(ctx context.Context, result string) {
+		if config.Metrics != nil {
+			config.Metrics.RecordSSOTokenInjection(ctx, result)
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			// Check if user is authenticated (set by OAuth ValidateToken middleware)
+			userInfo, ok := GetUserFromContext(ctx)
+			if !ok || userInfo == nil || userInfo.Email == "" {
+				// User not authenticated - just pass through
+				// The OAuth middleware will have already returned 401 if auth was required
+				recordMetric(ctx, instrumentation.SSOInjectionResultNoUser)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Check for forwarded access token
+			accessToken := r.Header.Get(SSOAccessTokenHeader)
+			if accessToken == "" {
+				// No forwarded access token - normal flow (user authenticated directly with inboxfewer)
+				recordMetric(ctx, instrumentation.SSOInjectionResultNoToken)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Extract optional refresh token and expiry
+			refreshToken := r.Header.Get(SSORefreshTokenHeader)
+			expiry := parseTokenExpiry(r.Header.Get(SSOTokenExpiryHeader))
+
+			// Build OAuth2 token
+			token := &oauth2.Token{
+				AccessToken:  accessToken,
+				RefreshToken: refreshToken,
+				TokenType:    "Bearer",
+				Expiry:       expiry,
+			}
+
+			// Store the forwarded access token for this user
+			storeCtx, cancel := context.WithTimeout(ctx, tokenStoreTimeout)
+			storeErr := config.Store.SaveToken(storeCtx, userInfo.Email, token)
+			cancel()
+
+			if storeErr != nil {
+				logger.Error("Failed to store forwarded SSO access token",
+					"email", hashEmailForLog(userInfo.Email),
+					"error", storeErr,
+				)
+				recordMetric(ctx, instrumentation.SSOInjectionResultStoreFailed)
+				// Continue anyway - we can still inject the token into context
+			} else {
+				logger.Info("Stored forwarded SSO access token",
+					"email", hashEmailForLog(userInfo.Email),
+					"has_refresh_token", refreshToken != "",
+					"expires_in", time.Until(expiry).Round(time.Second).String(),
+					"is_sso", userInfo.IsSSO(),
+				)
+			}
+
+			// Inject the access token into the request context for downstream use.
+			// This allows MCP tools to access the Google token via GetGoogleAccessTokenFromContext()
+			// without having to look it up from the store.
+			//
+			// This pattern mirrors mcp-kubernetes's ContextWithAccessToken approach,
+			// enabling efficient token propagation through the request lifecycle.
+			ctx = ContextWithGoogleAccessToken(ctx, accessToken)
+			r = r.WithContext(ctx)
+
+			// Use IsSSO() to detect SSO flow for metrics (mcp-oauth v0.2.43+)
+			// This is more robust than just checking for header presence
+			if userInfo.IsSSO() {
+				logger.Debug("SSO token injection: using SSO-forwarded token",
+					"email", hashEmailForLog(userInfo.Email))
+				recordMetric(ctx, instrumentation.SSOInjectionResultSuccess)
+			} else {
+				// Non-SSO flow with access token header (unusual but supported)
+				logger.Debug("SSO token injection: token stored for non-SSO user",
+					"email", hashEmailForLog(userInfo.Email))
+				if storeErr == nil {
+					recordMetric(ctx, instrumentation.SSOInjectionResultStored)
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// parseTokenExpiry parses the token expiry header value.
+// Returns a default expiry of 1 hour from now if the value is empty or invalid.
+func parseTokenExpiry(expiryStr string) time.Time {
+	if expiryStr == "" {
+		return time.Now().Add(defaultAccessTokenExpiry)
+	}
+
+	expiry, err := time.Parse(time.RFC3339, expiryStr)
+	if err != nil {
+		// Invalid format - use default
+		return time.Now().Add(defaultAccessTokenExpiry)
+	}
+
+	return expiry
+}
+
+// hashEmailForLog returns a partially masked version of the email for logging.
+// This prevents PII leakage in logs while still allowing correlation.
+// Format: first 2 chars of local part + "***@" + full domain (e.g., "te***@example.com")
+func hashEmailForLog(email string) string {
+	if email == "" {
+		return ""
+	}
+
+	// Short emails can't be meaningfully masked
+	if len(email) <= 8 {
+		return "***"
+	}
+
+	// Split email into local part and domain
+	localPart, domain, found := strings.Cut(email, "@")
+	if !found || localPart == "" || domain == "" {
+		return "***"
+	}
+
+	// Show first 2 chars of local part and full domain
+	if len(localPart) <= 2 {
+		return localPart + "***@" + domain
+	}
+	return localPart[:2] + "***@" + domain
+}
+
+// WrapWithSSOAccessToken wraps an HTTP handler with SSO access token middleware.
+// This is a convenience function that creates and applies the middleware.
+func WrapWithSSOAccessToken(handler http.Handler, store storage.TokenStore, logger *slog.Logger) http.Handler {
+	return SSOAccessTokenMiddleware(store, logger)(handler)
+}
+
+// WrapWithSSOAccessTokenAndMetrics wraps an HTTP handler with SSO access token middleware including metrics.
+// This is the preferred way to wrap handlers when metrics are available.
+func WrapWithSSOAccessTokenAndMetrics(handler http.Handler, store storage.TokenStore, logger *slog.Logger, metrics SSOMetricsRecorder) http.Handler {
+	return SSOAccessTokenMiddlewareWithConfig(&SSOMiddlewareConfig{
+		Store:   store,
+		Logger:  logger,
+		Metrics: metrics,
+	})(handler)
+}

--- a/internal/mcp/oauth/sso_access_token_test.go
+++ b/internal/mcp/oauth/sso_access_token_test.go
@@ -1,0 +1,605 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	mcpoauth "github.com/giantswarm/mcp-oauth"
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+func TestSSOAccessTokenMiddleware_NoUser(t *testing.T) {
+	// Test that requests without authenticated user pass through without storing tokens
+	store := memory.New()
+	defer store.Stop()
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "test-access-token")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestSSOAccessTokenMiddleware_NoAccessToken(t *testing.T) {
+	// Test that requests without X-Google-Access-Token header pass through normally
+	store := memory.New()
+	defer store.Stop()
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Create request with authenticated user context but no access token header
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	userInfo := &providers.UserInfo{
+		Email: "test@example.com",
+		Name:  "Test User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Token should not be stored
+	_, err := store.GetToken(req.Context(), "test@example.com")
+	assert.Error(t, err)
+}
+
+func TestSSOAccessTokenMiddleware_StoresAccessToken(t *testing.T) {
+	// Test that valid SSO access tokens are stored correctly
+	store := memory.New()
+	defer store.Stop()
+
+	var handlerCalled bool
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Create request with authenticated user context and access token header
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "forwarded-access-token")
+
+	userInfo := &providers.UserInfo{
+		Email: "sso-user@example.com",
+		Name:  "SSO User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, handlerCalled)
+
+	// Token should be stored
+	token, err := store.GetToken(req.Context(), "sso-user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "forwarded-access-token", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	// Expiry should be approximately 1 hour from now (default)
+	assert.WithinDuration(t, time.Now().Add(1*time.Hour), token.Expiry, 5*time.Second)
+}
+
+func TestSSOAccessTokenMiddleware_WithRefreshToken(t *testing.T) {
+	// Test that refresh tokens are stored when provided
+	store := memory.New()
+	defer store.Stop()
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "access-token")
+	req.Header.Set(SSORefreshTokenHeader, "refresh-token")
+
+	userInfo := &providers.UserInfo{
+		Email: "refresh-user@example.com",
+		Name:  "Refresh User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	token, err := store.GetToken(req.Context(), "refresh-user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "access-token", token.AccessToken)
+	assert.Equal(t, "refresh-token", token.RefreshToken)
+}
+
+func TestSSOAccessTokenMiddleware_WithExpiry(t *testing.T) {
+	// Test that custom expiry times are respected
+	store := memory.New()
+	defer store.Stop()
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	expectedExpiry := time.Now().Add(2 * time.Hour).UTC()
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "access-token")
+	req.Header.Set(SSOTokenExpiryHeader, expectedExpiry.Format(time.RFC3339))
+
+	userInfo := &providers.UserInfo{
+		Email: "expiry-user@example.com",
+		Name:  "Expiry User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	token, err := store.GetToken(req.Context(), "expiry-user@example.com")
+	require.NoError(t, err)
+	// Allow 1 second tolerance for parsing/storage
+	assert.WithinDuration(t, expectedExpiry, token.Expiry, 1*time.Second)
+}
+
+func TestSSOAccessTokenMiddleware_InvalidExpiry(t *testing.T) {
+	// Test that invalid expiry format falls back to default
+	store := memory.New()
+	defer store.Stop()
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "access-token")
+	req.Header.Set(SSOTokenExpiryHeader, "invalid-date-format")
+
+	userInfo := &providers.UserInfo{
+		Email: "invalid-expiry@example.com",
+		Name:  "Invalid Expiry User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	token, err := store.GetToken(req.Context(), "invalid-expiry@example.com")
+	require.NoError(t, err)
+	// Should fall back to default ~1 hour expiry
+	assert.WithinDuration(t, time.Now().Add(1*time.Hour), token.Expiry, 5*time.Second)
+}
+
+func TestSSOAccessTokenMiddleware_OverwritesExistingToken(t *testing.T) {
+	// Test that new SSO tokens overwrite existing tokens
+	store := memory.New()
+	defer store.Stop()
+
+	// Pre-store an existing token
+	existingToken := &oauth2.Token{
+		AccessToken: "old-access-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(30 * time.Minute),
+	}
+	err := store.SaveToken(context.Background(), "overwrite-user@example.com", existingToken)
+	require.NoError(t, err)
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "new-access-token")
+
+	userInfo := &providers.UserInfo{
+		Email: "overwrite-user@example.com",
+		Name:  "Overwrite User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Token should be updated with new value
+	token, err := store.GetToken(req.Context(), "overwrite-user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", token.AccessToken)
+}
+
+func TestParseTokenExpiry(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantNear time.Time
+	}{
+		{
+			name:     "empty string uses default",
+			input:    "",
+			wantNear: time.Now().Add(1 * time.Hour),
+		},
+		{
+			name:     "invalid format uses default",
+			input:    "not-a-date",
+			wantNear: time.Now().Add(1 * time.Hour),
+		},
+		{
+			name:     "valid RFC3339",
+			input:    "2024-01-20T15:04:05Z",
+			wantNear: time.Date(2024, 1, 20, 15, 4, 5, 0, time.UTC),
+		},
+		{
+			name:     "valid RFC3339 with timezone",
+			input:    "2024-01-20T15:04:05+02:00",
+			wantNear: time.Date(2024, 1, 20, 13, 4, 5, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTokenExpiry(tt.input)
+			assert.WithinDuration(t, tt.wantNear, got, 5*time.Second)
+		})
+	}
+}
+
+func TestHashEmailForLog(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{
+			name:  "empty email",
+			email: "",
+			want:  "",
+		},
+		{
+			name:  "short email",
+			email: "a@b.com",
+			want:  "***",
+		},
+		{
+			name:  "normal email",
+			email: "testuser@example.com",
+			want:  "te***@example.com",
+		},
+		{
+			name:  "short local part",
+			email: "ab@example.com",
+			want:  "ab***@example.com",
+		},
+		{
+			name:  "no at sign",
+			email: "invalidemail",
+			want:  "***",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hashEmailForLog(tt.email)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWrapWithSSOAccessToken(t *testing.T) {
+	// Test the convenience wrapper function
+	store := memory.New()
+	defer store.Stop()
+
+	var handlerCalled bool
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := WrapWithSSOAccessToken(innerHandler, store, nil)
+	require.NotNil(t, wrapped)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestMiddlewareChainOrdering_Integration tests the correct middleware chain ordering.
+// This is a critical integration test that verifies:
+//   - ValidateToken middleware runs BEFORE SSOAccessToken middleware
+//   - SSOAccessToken can see user info set by ValidateToken
+//   - Access tokens are correctly stored when both middlewares are properly ordered
+//
+// The correct chain is: ValidateToken -> SSOAccessToken -> handler
+// NOT: SSOAccessToken -> ValidateToken -> handler (which would fail)
+func TestMiddlewareChainOrdering_Integration(t *testing.T) {
+	store := memory.New()
+	defer store.Stop()
+
+	// Track what happened in each layer
+	var (
+		mcpHandlerCalled  bool
+		userSeenInHandler string
+	)
+
+	// The innermost handler (MCP endpoint)
+	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mcpHandlerCalled = true
+		// Check if user info is available
+		if userInfo, ok := GetUserFromContext(r.Context()); ok && userInfo != nil {
+			userSeenInHandler = userInfo.Email
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Simulate ValidateToken middleware - sets user info in context
+	// In production, this validates the JWT and extracts user info
+	simulatedValidateToken := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate successful token validation - set user info in context
+			userInfo := &providers.UserInfo{
+				Email: "integration-test@example.com",
+				Name:  "Integration Test User",
+			}
+			ctx := mcpoauth.ContextWithUserInfo(r.Context(), userInfo)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+
+	// Build the middleware chain in the CORRECT order:
+	// Request -> ValidateToken -> SSOAccessToken -> mcpHandler
+	//
+	// Wrapping order (inside-out):
+	// 1. SSO wraps mcpHandler
+	// 2. ValidateToken wraps SSO
+	ssoHandler := WrapWithSSOAccessToken(mcpHandler, store, nil)
+	validatedHandler := simulatedValidateToken(ssoHandler)
+
+	// Create request with SSO headers
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "integration-test-access-token")
+	req.Header.Set(SSORefreshTokenHeader, "integration-test-refresh-token")
+
+	rec := httptest.NewRecorder()
+	validatedHandler.ServeHTTP(rec, req)
+
+	// Verify the request completed successfully
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, mcpHandlerCalled, "MCP handler should have been called")
+	assert.Equal(t, "integration-test@example.com", userSeenInHandler, "User info should be visible in handler")
+
+	// Verify the access token was stored correctly
+	token, err := store.GetToken(context.Background(), "integration-test@example.com")
+	require.NoError(t, err, "Access token should have been stored")
+	assert.Equal(t, "integration-test-access-token", token.AccessToken)
+	assert.Equal(t, "integration-test-refresh-token", token.RefreshToken)
+}
+
+// TestMiddlewareChainOrdering_WrongOrder verifies that the WRONG middleware order fails to store tokens.
+// This test documents the bug that was fixed: if SSOAccessToken runs before ValidateToken,
+// no user info is available and tokens are not stored.
+func TestMiddlewareChainOrdering_WrongOrder(t *testing.T) {
+	store := memory.New()
+	defer store.Stop()
+
+	var mcpHandlerCalled bool
+
+	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mcpHandlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Simulate ValidateToken middleware
+	simulatedValidateToken := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userInfo := &providers.UserInfo{
+				Email: "wrong-order-user@example.com",
+				Name:  "Wrong Order User",
+			}
+			ctx := mcpoauth.ContextWithUserInfo(r.Context(), userInfo)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+
+	// Build the middleware chain in the WRONG order:
+	// Request -> SSOAccessToken -> ValidateToken -> mcpHandler
+	//
+	// This is wrong because SSOAccessToken runs BEFORE user info is set!
+	validatedHandler := simulatedValidateToken(mcpHandler)
+	ssoHandler := WrapWithSSOAccessToken(validatedHandler, store, nil) // WRONG: SSO wraps validated
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "should-not-be-stored")
+
+	rec := httptest.NewRecorder()
+	ssoHandler.ServeHTTP(rec, req)
+
+	// Request still succeeds (passes through)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, mcpHandlerCalled)
+
+	// But token was NOT stored because user info wasn't available when SSO middleware ran
+	_, err := store.GetToken(context.Background(), "wrong-order-user@example.com")
+	assert.Error(t, err, "Token should NOT be stored with wrong middleware order")
+}
+
+// TestSSOAccessTokenMiddleware_InjectsIntoContext verifies that the access token
+// is injected into the request context via ContextWithGoogleAccessToken.
+func TestSSOAccessTokenMiddleware_InjectsIntoContext(t *testing.T) {
+	store := memory.New()
+	defer store.Stop()
+
+	var capturedToken string
+	var tokenFound bool
+
+	handler := SSOAccessTokenMiddleware(store, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if token was injected into context
+		capturedToken, tokenFound = GetGoogleAccessTokenFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set(SSOAccessTokenHeader, "context-injected-token")
+
+	userInfo := &providers.UserInfo{
+		Email: "context-user@example.com",
+		Name:  "Context User",
+	}
+	req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, tokenFound, "Token should be found in context")
+	assert.Equal(t, "context-injected-token", capturedToken)
+}
+
+// mockSSOMetricsRecorder tracks SSO token injection metrics for testing
+type mockSSOMetricsRecorder struct {
+	results []string
+}
+
+func (m *mockSSOMetricsRecorder) RecordSSOTokenInjection(ctx context.Context, result string) {
+	m.results = append(m.results, result)
+}
+
+// TestSSOAccessTokenMiddleware_WithMetrics verifies that metrics are recorded correctly.
+func TestSSOAccessTokenMiddleware_WithMetrics(t *testing.T) {
+	store := memory.New()
+	defer store.Stop()
+
+	metrics := &mockSSOMetricsRecorder{}
+
+	handler := SSOAccessTokenMiddlewareWithConfig(&SSOMiddlewareConfig{
+		Store:   store,
+		Logger:  nil,
+		Metrics: metrics,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("records no_user when user not authenticated", func(t *testing.T) {
+		metrics.results = nil
+		req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		req.Header.Set(SSOAccessTokenHeader, "test-token")
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.Len(t, metrics.results, 1)
+		assert.Equal(t, "no_user", metrics.results[0])
+	})
+
+	t.Run("records no_token when header not present", func(t *testing.T) {
+		metrics.results = nil
+		req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		// No access token header
+
+		userInfo := &providers.UserInfo{
+			Email: "notoken-user@example.com",
+			Name:  "No Token User",
+		}
+		req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.Len(t, metrics.results, 1)
+		assert.Equal(t, "no_token", metrics.results[0])
+	})
+
+	t.Run("records stored when token is stored for non-SSO user", func(t *testing.T) {
+		metrics.results = nil
+		req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		req.Header.Set(SSOAccessTokenHeader, "stored-token")
+
+		// Non-SSO user (IsSSO() returns false by default)
+		userInfo := &providers.UserInfo{
+			Email: "stored-user@example.com",
+			Name:  "Stored User",
+		}
+		req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.Len(t, metrics.results, 1)
+		assert.Equal(t, "stored", metrics.results[0])
+	})
+
+	t.Run("records sso_success when IsSSO is true", func(t *testing.T) {
+		metrics.results = nil
+		req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		req.Header.Set(SSOAccessTokenHeader, "sso-token")
+
+		// SSO user - set TokenSource to make IsSSO() return true
+		userInfo := &providers.UserInfo{
+			Email:       "sso-user@example.com",
+			Name:        "SSO User",
+			TokenSource: "sso", // This makes IsSSO() return true
+		}
+		req = req.WithContext(mcpoauth.ContextWithUserInfo(req.Context(), userInfo))
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.Len(t, metrics.results, 1)
+		assert.Equal(t, "sso_success", metrics.results[0])
+	})
+}
+
+// TestWrapWithSSOAccessTokenAndMetrics tests the metrics-enabled wrapper function.
+func TestWrapWithSSOAccessTokenAndMetrics(t *testing.T) {
+	store := memory.New()
+	defer store.Stop()
+
+	metrics := &mockSSOMetricsRecorder{}
+
+	var handlerCalled bool
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := WrapWithSSOAccessTokenAndMetrics(innerHandler, store, nil, metrics)
+	require.NotNil(t, wrapped)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// Should record no_user since no user info in context
+	require.Len(t, metrics.results, 1)
+	assert.Equal(t, "no_user", metrics.results[0])
+}


### PR DESCRIPTION
## Summary

Enable SSO flows where an upstream MCP aggregator (like muster) forwards both the ID token (for authentication) and the Google access token (for API access) to inboxfewer.

## Key Features

- **SSO Access Token Middleware**: Extracts Google access tokens from `X-Google-Access-Token` header
- **Context-Based Token Propagation**: `ContextWithGoogleAccessToken()` / `GetGoogleAccessTokenFromContext()` aligned with mcp-kubernetes patterns
- **HTTPContextFunc**: Propagates tokens from HTTP context to mcp-go's internal context for MCP tools
- **SSO Token Injection Metrics**: `sso_token_injection_total` counter with result labels
- **IsSSO() Detection**: Uses mcp-oauth v0.2.45 for robust SSO flow detection

## Security Fixes

- **Fixed middleware ordering**: `ValidateToken -> SSOAccessToken -> handler` (critical for SSO to work)
- **Added integration tests** to prevent middleware ordering regressions

## Dependencies

- Upgraded mcp-oauth from v0.2.40 to v0.2.45 (adds `IsSSO()` method)

## Comparison with mcp-kubernetes

| Feature | inboxfewer | mcp-kubernetes |
|---------|------------|----------------|
| Token type needed | Google Access Token | ID Token (for K8s OIDC) |
| Header used | `X-Google-Access-Token` | Bearer token in `Authorization` |
| Context propagation | `ContextWithGoogleAccessToken()` | `ContextWithAccessToken()` |
| HTTPContextFunc | Yes | Yes |
| IsSSO() detection | Yes (v0.2.45+) | Yes |
| Token injection metrics | Yes | Yes |

## Test plan

- [x] All existing tests pass
- [x] New SSO access token middleware tests pass
- [x] New context function tests pass  
- [x] New metrics recording tests pass
- [x] Integration tests for middleware ordering pass
- [x] Code formatted with goimports/go fmt
- [x] Rebased cleanly on main

---

## Merge Commit Message

```
feat(oauth): Add SSO access token forwarding for Google API access (#104)

Enable SSO flows where an upstream MCP aggregator (like muster) forwards
both the ID token (for authentication) and the Google access token (for
API access) to inboxfewer.

Key features:
- SSO access token middleware extracts tokens from X-Google-Access-Token header
- Context-based token propagation (ContextWithGoogleAccessToken) aligned with
  mcp-kubernetes patterns
- HTTPContextFunc propagates tokens to mcp-go's internal context for tools
- SSO token injection metrics (sso_token_injection_total)

Security fixes:
- Corrected middleware ordering: ValidateToken -> SSOAccessToken -> handler
- Added integration tests to prevent middleware ordering regressions

Dependencies:
- Upgraded mcp-oauth from v0.2.40 to v0.2.45 (IsSSO() method support)

Closes #97, #103
```

---

Closes #97, #103