### PR TITLE
chore: add explicit permissions to gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   scan:
     name: gitleaks


### PR DESCRIPTION
Adds explicit `permissions:` block so the gitleaks action can read PR commits and post review comments. Without this, repos with the GitHub default of read-only `GITHUB_TOKEN` permissions fail the `pull_request` event scan with HTTP 403.